### PR TITLE
Links opening automatically in a new tab

### DIFF
--- a/src/HN/View/Home.hs
+++ b/src/HN/View/Home.hs
@@ -29,7 +29,7 @@ grouped now groups = template "grouped" (return ()) $ do
             table !. "table" $
               forM_ items $ \item ->
                 tr $ td $ do
-                  a ! href (toValue (show (iLink item))) $ toHtml (iTitle item)
+                  a ! href (toValue (show (iLink item))) ! target "_blank" $ toHtml (iTitle item)
                   " — "
                   case iSource item of
                     Github ->
@@ -59,7 +59,7 @@ mixed now items = template "mixed" (return ()) $ do
                     !. "favicon"
                     ! title (toValue (iSource item))
               td $ do
-                a ! href (toValue (show (iLink item))) $ toHtml (iTitle item)
+                a ! href (toValue (show (iLink item))) ! target "_blank" $ toHtml (iTitle item)
                 " — "
                 case iSource item of
                   Github ->


### PR DESCRIPTION
I would like to see links opening by themselves in a new tab. This is useful when navigating different _news_ at the same time, avoiding pressing the back button. This can be done manually by the user but, IMHO, it is more convenient if it is done by default.
