### PR TITLE
Add source to rss item title

### DIFF
--- a/src/HN/Controllers.hs
+++ b/src/HN/Controllers.hs
@@ -3,7 +3,6 @@
 
 module HN.Controllers where
 
-import           HN.Blaze
 import           HN.Monads
 import           HN.Model.Items
 import           HN.Types
@@ -38,7 +37,7 @@ feed = do
   outputRSS "Haskell News"
             "http://haskellnews.org/"
             (map (\DItem{..} -> (zonedTimeToUTC iAdded
-                                ,iTitle
+                                ,T.pack ("[" ++ show iSource ++ "] ") `T.append` iTitle
                                 ,""
                                 ,T.pack $ show iLink))
                  items)

--- a/src/HN/View/Home.hs
+++ b/src/HN/View/Home.hs
@@ -10,7 +10,6 @@ import           HN.View.Template
 
 import           Data.List.Split
 import qualified Data.Text as T
-import           Data.Time
 import           Data.Time.Relative
 import           Network.URI
 import           System.Locale

--- a/src/Text/Blaze/Bootstrap.hs
+++ b/src/Text/Blaze/Bootstrap.hs
@@ -3,7 +3,6 @@
 
 module Text.Blaze.Bootstrap where
 
-import Text.Blaze
 import Text.Blaze.Html5
 import Text.Blaze.Extra
 import Prelude (($))


### PR DESCRIPTION
As a HaskellNews user I want to see source of the rss item in the title like

`[hackage] xml-types 0.3.4` instead of current `xml-types 0.3.4`.
