### PR TITLE
adds rss feed <link> to template <head>

### DIFF
--- a/src/HN/View/Template.hs
+++ b/src/HN/View/Template.hs
@@ -11,6 +11,7 @@ template name innerhead innerbody = do
   docType
   html $ do
     head $ do H.title "Haskell News"
+              link ! rel "alternate"  ! type_ "application/rss+xml" ! title "Haskell News Feed" ! href "/feed"
               link ! rel "stylesheet" ! type_ "text/css" ! href "/css/bootstrap.min.css"
               link ! rel "stylesheet" ! type_ "text/css" ! href "/css/bootstrap-responsive.css"
               link ! rel "stylesheet" ! type_ "text/css" ! href "/css/haskellnews.css"


### PR DESCRIPTION
First, thank you very much for Haskell News. It is the only source of info I use to stay updated on all things Haskell.

I was trying to find the feed URL and ended up going to the source code to dig it out. This pull request just throws it into a `<link>` tag in the `<head>` of the site template. Maybe it'll make it easier for others in the future to find the feed?

Thanks again!
