### PR TITLE
HaskellWiki URL update

### DIFF
--- a/src/HN/Model/Feeds.hs
+++ b/src/HN/Model/Feeds.hs
@@ -40,7 +40,7 @@ importStackOverflow = do
   importGeneric StackOverflow "http://programmers.stackexchange.com/feeds/tag/haskell"
 
 importHaskellWiki =
-  importGeneric HaskellWiki "http://www.haskell.org/haskellwiki/index.php?title=Special:RecentChanges&feed=rss"
+  importGeneric HaskellWiki "http://wiki.haskell.org/index.php?title=Special:RecentChanges&feed=atom"
 
 importHackage =
   importGeneric Hackage "http://hackage.haskell.org/packages/recent.rss"


### PR DESCRIPTION
The current HaskellWiki group is timestamped to "a year ago" despite the wiki having recent changes.

http://www.haskell.org/haskellwiki/index.php?title=Special:RecentChanges&feed=rss
to
http://wiki.haskell.org/index.php?title=Special:RecentChanges&feed=atom
